### PR TITLE
Fix: Prediction slot size does not match sentence size

### DIFF
--- a/utils/loader.py
+++ b/utils/loader.py
@@ -392,9 +392,9 @@ class DatasetManager(object):
                             item[-1].extend(['<PAD>'] * (max_len - len_list[index]))
 
         if items is not None:
-            return trans_texts, trans_items, seq_lens
+            return trans_texts, trans_items, seq_lens, sorted_index
         else:
-            return trans_texts, seq_lens
+            return trans_texts, seq_lens, sorted_index
 
     @staticmethod
     def __collate_fn(batch):


### PR DESCRIPTION
This pull request fixes the problem mentioned in issue #6.
Because it's a visualization bug, so I didn't restore the order in train and valid time.
**Only in test time will it be restored.**